### PR TITLE
把 keybinding 的定義移到 keybinding.go

### DIFF
--- a/keybinding.go
+++ b/keybinding.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+//Keybinding | type of vscodevim keybinding
+type Keybinding struct {
+	Before []string `json:"before"`
+	After  []string `json:"after"`
+}
+
+type KeybindingsOfAllModes struct {
+	Normal   []Keybinding `json:"vim.normalModeKeyBindings"`
+	Nnoremap []Keybinding `json:"vim.normalModeKeyBindingsNonRecursive"`
+	Insert   []Keybinding `json:"vim.insertModeKeyBindings"`
+	Inoremap []Keybinding `json:"vim.insertModeKeyBindingsNonRecursive"`
+	Visual   []Keybinding `json:"vim.visualModeKeyBindings"`
+	Vnoremap []Keybinding `json:"vim.visualModeKeyBindingsNonRecursive"`
+}
+
+// implement Stringer interface for KeybindingsOfAllModes
+func (k KeybindingsOfAllModes) String() string {
+	jsonData := bytes.NewBuffer([]byte{})
+	jsonEncoder := json.NewEncoder(jsonData)
+	jsonEncoder.SetEscapeHTML(false)
+	jsonEncoder.SetIndent("", "  ")
+	jsonEncoder.Encode(k)
+	return jsonData.String()
+}

--- a/main.go
+++ b/main.go
@@ -3,39 +3,12 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"strings"
 )
-
-//Keybinding | type of vscodevim keybinding
-type Keybinding struct {
-	Before []string `json:"before"`
-	After  []string `json:"after"`
-}
-
-//KeybindingsOfAllModes   implement all kind of vim mode
-type KeybindingsOfAllModes struct {
-	Normal   []Keybinding `json:"vim.normalModeKeyBindings"`
-	Nnoremap []Keybinding `json:"vim.normalModeKeyBindingsNonRecursive"`
-	Insert   []Keybinding `json:"vim.insertModeKeyBindings"`
-	Inoremap []Keybinding `json:"vim.insertModeKeyBindingsNonRecursive"`
-	Visual   []Keybinding `json:"vim.visualModeKeyBindings"`
-	Vnoremap []Keybinding `json:"vim.visualModeKeyBindingsNonRecursive"`
-}
-
-// implement Stringer interface for KeybindingsOfAllModes
-func (k KeybindingsOfAllModes) String() string {
-	jsonData := bytes.NewBuffer([]byte{})
-	jsonEncoder := json.NewEncoder(jsonData)
-	jsonEncoder.SetEscapeHTML(false)
-	jsonEncoder.SetIndent("", "  ")
-	jsonEncoder.Encode(k)
-	return jsonData.String()
-}
 
 // ProcessDistrubutionKeybindingModes split and process different type of vim mode
 func ProcessDistrubutionKeybindingModes(matchArr []string, matchList *[]Keybinding) {


### PR DESCRIPTION
因為我覺得 master 越來越長了，Keybinding 相關型別的定義也有點多，所以覺得可以移到 `keybinding.go` 去，這樣 main 就可以更專注在主要邏輯上

如果你覺得不錯的話那就 merge，或是覺得不需要那就放著也沒差XD

> 提醒一下：如果你原本是下 `go run main.go` 在執行程式，移過去之後因為變成有兩個 Go file，所以要下 `go run .` 或是 `go run *.go` 來執行程式（我是都用前者啦XD，比 `go run main.go` 短很多）